### PR TITLE
feat: add depth-parallax hero

### DIFF
--- a/.github/workflows/generate-depth.yml
+++ b/.github/workflows/generate-depth.yml
@@ -1,0 +1,41 @@
+name: Generate depth map
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'public/hero/montanas.jpg'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --extra-index-url https://download.pytorch.org/whl/cpu torch
+          pip install timm opencv-python-headless Pillow
+
+      - name: Generate depth map
+        run: python scripts/generate_depth.py
+
+      - name: Commit depth map
+        run: |
+          if [ -n "$(git status --porcelain public/hero/montanas-depth.png)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add public/hero/montanas-depth.png
+            git commit -m "chore: update depth map"
+            git push
+          fi

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import '../styles/globals.css';
+
+export const metadata: Metadata = {
+  title: 'Montañas | Parallax',
+  description: 'Experiencia inmersiva con parallax 3D usando mapa de profundidad.'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="es">
+      <head>
+        <link rel="preload" as="image" href="/hero/montanas.jpg" />
+      </head>
+      <body>
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: -1,
+            backgroundColor: '#000'
+          }}
+        />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,32 @@
+import HeroDepth from '@/components/HeroDepth';
+
+export default function Home() {
+  return (
+    <main>
+      <HeroDepth fadeStart={0.72} />
+      <section className="section">
+        <h2>Explora las cumbres</h2>
+        <p>
+          Un paisaje enigmático que reacciona a tus movimientos, revelando la profundidad de las
+          montañas gracias a un mapa de profundidad generado automáticamente. Desplázate para
+          encontrar más contenido sumergido en la oscuridad.
+        </p>
+      </section>
+      <section className="section">
+        <h2>Experiencia inmersiva</h2>
+        <p>
+          Interactúa con el entorno moviendo el cursor o inclinando tu dispositivo. Las capas más
+          cercanas cobran vida mientras el cielo permanece casi inmóvil, creando una sensación 3D
+          realista.
+        </p>
+      </section>
+      <section className="section">
+        <h2>Accesible y adaptable</h2>
+        <p>
+          El efecto se desactiva automáticamente si prefieres menos movimiento y ofrece un fallback
+          elegante cuando el mapa de profundidad no está disponible.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/components/HeroDepth.tsx
+++ b/components/HeroDepth.tsx
@@ -1,0 +1,412 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+
+type DepthStatus = 'unknown' | 'available' | 'missing';
+
+type HeroDepthProps = {
+  fadeStart?: number;
+  strength?: number;
+};
+
+const clampFade = (value: number) => Math.min(Math.max(value, 0.65), 0.85);
+
+const shaders = {
+  vertex: /* glsl */ `
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = vec4(position, 1.0);
+    }
+  `,
+  fragment: /* glsl */ `
+    uniform sampler2D u_tex;
+    uniform sampler2D u_depth;
+    uniform vec2 u_mouse;
+    uniform vec2 u_res;
+    uniform float u_strength;
+
+    void main() {
+      vec2 uv = gl_FragCoord.xy / u_res;
+      float d = texture2D(u_depth, uv).r;
+      vec2 parallax = u_mouse * (d - 0.5) * u_strength;
+      vec4 color = texture2D(u_tex, uv + parallax);
+      gl_FragColor = color;
+    }
+  `
+};
+
+export default function HeroDepth({ fadeStart = 0.7, strength = 0.06 }: HeroDepthProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const fallbackRef = useRef<HTMLDivElement | null>(null);
+  const inputControllerRef = useRef<{ setTarget: (x: number, y: number) => void } | null>(null);
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const [depthStatus, setDepthStatus] = useState<DepthStatus>('unknown');
+  const [mode, setMode] = useState<'static' | 'three' | 'fallback'>('static');
+
+  const fadeValue = useMemo(() => clampFade(fadeStart), [fadeStart]);
+  const maskStyle = useMemo(
+    () => ({
+      maskImage: `linear-gradient(to bottom, rgba(0,0,0,1) ${fadeValue * 100}%, rgba(0,0,0,0) 100%)`,
+      WebkitMaskImage: `linear-gradient(to bottom, rgba(0,0,0,1) ${fadeValue * 100}%, rgba(0,0,0,0) 100%)`
+    }),
+    [fadeValue]
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduceMotion(media.matches);
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const img = new Image();
+    img.src = '/hero/montanas-depth.png';
+    const handleLoad = () => setDepthStatus('available');
+    const handleError = () => setDepthStatus('missing');
+    img.addEventListener('load', handleLoad, { once: true });
+    img.addEventListener('error', handleError, { once: true });
+    return () => {
+      img.removeEventListener('load', handleLoad);
+      img.removeEventListener('error', handleError);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (reduceMotion) {
+      setMode('static');
+      return;
+    }
+    if (depthStatus === 'available') {
+      setMode('three');
+    } else if (depthStatus === 'missing') {
+      setMode('fallback');
+    }
+  }, [reduceMotion, depthStatus]);
+
+  useEffect(() => {
+    if (mode !== 'fallback') return;
+
+    const state = {
+      target: { x: 0, y: 0 },
+      current: { x: 0, y: 0 },
+      raf: null as number | null
+    };
+
+    const step = () => {
+      state.raf = null;
+      state.current.x += (state.target.x - state.current.x) * 0.075;
+      state.current.y += (state.target.y - state.current.y) * 0.075;
+      if (fallbackRef.current) {
+        const maxShift = 30;
+        fallbackRef.current.style.transform = `translate3d(${state.current.x * maxShift}px, ${state.current.y * maxShift}px, 0)`;
+      }
+      if (Math.abs(state.current.x - state.target.x) > 0.001 || Math.abs(state.current.y - state.target.y) > 0.001) {
+        state.raf = requestAnimationFrame(step);
+      }
+    };
+
+    inputControllerRef.current = {
+      setTarget: (x, y) => {
+        state.target.x = THREE.MathUtils.clamp(x, -1, 1);
+        state.target.y = THREE.MathUtils.clamp(y, -1, 1);
+        if (state.raf == null) {
+          state.raf = requestAnimationFrame(step);
+        }
+      }
+    };
+
+    return () => {
+      if (state.raf != null) {
+        cancelAnimationFrame(state.raf);
+      }
+      if (fallbackRef.current) {
+        fallbackRef.current.style.transform = 'translate3d(0, 0, 0)';
+      }
+      inputControllerRef.current = null;
+    };
+  }, [mode]);
+
+  useEffect(() => {
+    if (mode !== 'three') return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    let disposed = false;
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight, false);
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
+    renderer.domElement.style.display = 'block';
+    renderer.domElement.setAttribute('aria-hidden', 'true');
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    const geometry = new THREE.PlaneGeometry(2, 2);
+
+    const loader = new THREE.TextureLoader();
+
+    const state = {
+      target: new THREE.Vector2(),
+      current: new THREE.Vector2(),
+      raf: null as number | null,
+      frame: null as number | null,
+      uniforms: null as THREE.ShaderMaterial['uniforms'] | null,
+      material: null as THREE.ShaderMaterial | null,
+      mesh: null as THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial> | null,
+      colorTex: null as THREE.Texture | null,
+      depthTex: null as THREE.Texture | null
+    };
+
+    const scheduleRender = () => {
+      if (state.frame != null) return;
+      state.frame = requestAnimationFrame(() => {
+        state.frame = null;
+        if (!state.uniforms) return;
+        const width = renderer.domElement.width;
+        const height = renderer.domElement.height;
+        (state.uniforms.u_res.value as THREE.Vector2).set(width, height);
+        renderer.render(scene, camera);
+      });
+    };
+
+    const step = () => {
+      state.raf = null;
+      state.current.lerp(state.target, 0.08);
+      if (state.uniforms) {
+        (state.uniforms.u_mouse.value as THREE.Vector2).copy(state.current);
+      }
+      scheduleRender();
+      if (state.current.distanceTo(state.target) > 0.001) {
+        state.raf = requestAnimationFrame(step);
+      }
+    };
+
+    inputControllerRef.current = {
+      setTarget: (x, y) => {
+        state.target.set(THREE.MathUtils.clamp(x, -1, 1), THREE.MathUtils.clamp(y, -1, 1));
+        if (state.raf == null) {
+          state.raf = requestAnimationFrame(step);
+        }
+      }
+    };
+
+    Promise.all([
+      loader.loadAsync('/hero/montanas.jpg'),
+      loader.loadAsync('/hero/montanas-depth.png')
+    ])
+      .then(([colorTex, depthTex]) => {
+        if (disposed) {
+          colorTex.dispose();
+          depthTex.dispose();
+          return;
+        }
+        colorTex.colorSpace = THREE.SRGBColorSpace;
+        colorTex.anisotropy = renderer.capabilities.getMaxAnisotropy();
+        colorTex.wrapS = THREE.ClampToEdgeWrapping;
+        colorTex.wrapT = THREE.ClampToEdgeWrapping;
+        depthTex.wrapS = THREE.ClampToEdgeWrapping;
+        depthTex.wrapT = THREE.ClampToEdgeWrapping;
+
+        const uniforms = {
+          u_tex: { value: colorTex },
+          u_depth: { value: depthTex },
+          u_mouse: { value: new THREE.Vector2() },
+          u_strength: { value: strength },
+          u_res: { value: new THREE.Vector2(renderer.domElement.width, renderer.domElement.height) }
+        } satisfies THREE.ShaderMaterialParameters['uniforms'];
+
+        const material = new THREE.ShaderMaterial({
+          uniforms,
+          vertexShader: shaders.vertex,
+          fragmentShader: shaders.fragment
+        });
+
+        const mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+
+        state.uniforms = uniforms;
+        state.material = material;
+        state.mesh = mesh;
+        state.colorTex = colorTex;
+        state.depthTex = depthTex;
+        if (state.raf == null) {
+          state.raf = requestAnimationFrame(step);
+        }
+        scheduleRender();
+      })
+      .catch(() => {
+        if (!disposed) {
+          setMode('fallback');
+        }
+      });
+
+    const handleResize = () => {
+      renderer.setSize(container.clientWidth, container.clientHeight, false);
+      scheduleRender();
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener('resize', handleResize);
+      if (state.raf != null) cancelAnimationFrame(state.raf);
+      if (state.frame != null) cancelAnimationFrame(state.frame);
+      if (state.mesh) scene.remove(state.mesh);
+      if (state.material) state.material.dispose();
+      if (state.colorTex) state.colorTex.dispose();
+      if (state.depthTex) state.depthTex.dispose();
+      geometry.dispose();
+      renderer.dispose();
+      renderer.domElement.remove();
+      inputControllerRef.current = null;
+    };
+  }, [mode, strength]);
+
+  useEffect(() => {
+    if (mode === 'static') return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const controller = inputControllerRef.current;
+      if (!controller) return;
+      const nx = (event.clientX / window.innerWidth) * 2 - 1;
+      const ny = -((event.clientY / window.innerHeight) * 2 - 1);
+      controller.setTarget(nx, ny);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+    };
+  }, [mode]);
+
+  useEffect(() => {
+    if (mode === 'static') return;
+    const container = containerRef.current;
+    if (!container || typeof window === 'undefined' || typeof DeviceOrientationEvent === 'undefined') {
+      return;
+    }
+
+    let cleanupRequest: (() => void) | null = null;
+    let orientationHandler: ((event: DeviceOrientationEvent) => void) | null = null;
+
+    const activateOrientation = () => {
+      if (orientationHandler) return;
+      orientationHandler = (event: DeviceOrientationEvent) => {
+        if (event.beta == null || event.gamma == null) return;
+        const gamma = THREE.MathUtils.clamp(event.gamma / 20, -1, 1);
+        const beta = THREE.MathUtils.clamp(event.beta / 20, -1, 1);
+        inputControllerRef.current?.setTarget(gamma, -beta * 0.8);
+      };
+      window.addEventListener('deviceorientation', orientationHandler);
+    };
+
+    const requestPermission = () => {
+      const anyDeviceOrientation = DeviceOrientationEvent as unknown as {
+        requestPermission?: () => Promise<'granted' | 'denied' | 'default'>;
+      };
+
+      if (typeof anyDeviceOrientation.requestPermission === 'function') {
+        const handler = () => {
+          anyDeviceOrientation
+            .requestPermission?.()
+            .then((response) => {
+              if (response === 'granted') {
+                activateOrientation();
+              }
+            })
+            .finally(() => {
+              container.removeEventListener('click', handler);
+              container.removeEventListener('touchstart', handler);
+            });
+        };
+        container.addEventListener('click', handler, { once: true, passive: true });
+        container.addEventListener('touchstart', handler, { once: true, passive: true });
+        cleanupRequest = () => {
+          container.removeEventListener('click', handler);
+          container.removeEventListener('touchstart', handler);
+        };
+      } else {
+        activateOrientation();
+      }
+    };
+
+    requestPermission();
+
+    return () => {
+      cleanupRequest?.();
+      if (orientationHandler) {
+        window.removeEventListener('deviceorientation', orientationHandler);
+      }
+    };
+  }, [mode]);
+
+  const description = 'Fotografía panorámica de montañas al atardecer con efecto de profundidad.';
+
+  return (
+    <section
+      aria-label={description}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100vh',
+        overflow: 'hidden',
+        backgroundColor: '#000',
+        ...maskStyle
+      }}
+      ref={containerRef}
+    >
+      {mode === 'static' ? (
+        <img
+          src="/hero/montanas.jpg"
+          alt={description}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            display: 'block'
+          }}
+        />
+      ) : null}
+      {mode === 'fallback' ? (
+        <div
+          ref={fallbackRef}
+          aria-hidden
+          style={{
+            width: '100%',
+            height: '100%',
+            backgroundImage: 'url(/hero/montanas.jpg)',
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            transform: 'translate3d(0, 0, 0)',
+            willChange: 'transform'
+          }}
+        />
+      ) : null}
+      <span
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          border: 0,
+          clip: 'rect(0 0 0 0)',
+          clipPath: 'inset(50%)',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap'
+        }}
+      >
+        {description}
+      </span>
+    </section>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "aisaweb2",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "three": "0.161.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.53",
+    "typescript": "5.3.3"
+  }
+}

--- a/scripts/generate_depth.py
+++ b/scripts/generate_depth.py
@@ -1,0 +1,61 @@
+import pathlib
+
+import cv2
+import numpy as np
+import torch
+
+MODEL_REPO = "intel-isl/MiDaS"
+MODEL_NAME = "DPT_Small"
+
+
+def load_image(path: pathlib.Path) -> np.ndarray:
+    image = cv2.imread(str(path))
+    if image is None:
+        raise FileNotFoundError(f"Could not load image: {path}")
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+
+def save_depth(depth: np.ndarray, template: np.ndarray, output_path: pathlib.Path) -> None:
+    depth = depth - depth.min()
+    if depth.max() > 0:
+        depth = depth / depth.max()
+    depth = (depth * 255.0).astype(np.uint8)
+    depth_resized = cv2.resize(depth, (template.shape[1], template.shape[0]), interpolation=cv2.INTER_CUBIC)
+    depth_resized = cv2.cvtColor(depth_resized, cv2.COLOR_GRAY2RGB)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(output_path), depth_resized)
+
+
+def run() -> None:
+    root = pathlib.Path(__file__).resolve().parents[1]
+    image_path = root / "public" / "hero" / "montanas.jpg"
+    output_path = root / "public" / "hero" / "montanas-depth.png"
+
+    image = load_image(image_path)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model_type = MODEL_NAME
+    model = torch.hub.load(MODEL_REPO, model_type)
+    model.to(device)
+    model.eval()
+
+    transforms = torch.hub.load(MODEL_REPO, "transforms")
+    transform = transforms.small_transform
+
+    input_batch = transform(image).to(device)
+
+    with torch.no_grad():
+        prediction = model(input_batch)
+        prediction = torch.nn.functional.interpolate(
+            prediction.unsqueeze(1),
+            size=image.shape[:2],
+            mode="bicubic",
+            align_corners=False,
+        ).squeeze()
+
+    depth_map = prediction.cpu().numpy()
+    save_depth(depth_map, image, output_path)
+
+
+if __name__ == "__main__":
+    run()

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,42 @@
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #000;
+  color: #fff;
+  min-height: 100vh;
+}
+
+main {
+  position: relative;
+  z-index: 1;
+}
+
+.section {
+  padding: 8rem 1.5rem;
+  max-width: 720px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.section h2 {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  margin-bottom: 1.5rem;
+}
+
+.section p {
+  font-size: clamp(1.125rem, 2vw, 1.35rem);
+  opacity: 0.85;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,45 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 App Router project with dark global styling and preload for the hero image
- implement a HeroDepth component that renders a depth-mapped parallax experience with fallbacks, reduced-motion support, and mobile orientation handling
- add automation to generate the depth map via MiDaS using a GitHub Actions workflow

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000


------
https://chatgpt.com/codex/tasks/task_e_68da9a8db640832d96926fa8b0b10426