### PR TITLE
feat(header): menú estático estilo “píldora” (AISA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ yarn-error.log*
 
 # Misc
 .DS_Store
+tsconfig.tsbuildinfo

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,15 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { Poppins } from 'next/font/google';
+import HeaderMenu from '@/components/HeaderMenu';
 import '../styles/globals.css';
+
+const poppins = Poppins({
+  subsets: ['latin'],
+  weight: ['300', '600'],
+  variable: '--font-poppins',
+  display: 'swap'
+});
 
 export const metadata: Metadata = {
   title: 'Montañas | Parallax',
@@ -13,11 +22,11 @@ export default function RootLayout({
   children: ReactNode;
 }) {
   return (
-    <html lang="es">
+    <html lang="es" className={poppins.variable}>
       <head>
         <link rel="preload" as="image" href="/hero/montanas.jpg" />
       </head>
-      <body>
+      <body className={poppins.className}>
         <div
           style={{
             position: 'fixed',
@@ -26,6 +35,7 @@ export default function RootLayout({
             backgroundColor: '#000'
           }}
         />
+        <HeaderMenu />
         {children}
       </body>
     </html>

--- a/components/AisaLogo.tsx
+++ b/components/AisaLogo.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
+
+type AisaLogoProps = Omit<ComponentPropsWithoutRef<'span'>, 'children'> & {
+  imgClassName?: string;
+};
+
+export default function AisaLogo({ className, imgClassName, ...props }: AisaLogoProps) {
+  const [hasError, setHasError] = useState(false);
+
+  if (hasError) {
+    return (
+      <span className={className} {...props}>
+        AISA
+      </span>
+    );
+  }
+
+  return (
+    <span className={className} {...props}>
+      <img
+        src="/brand/aisa-logo.svg"
+        alt="AISA"
+        className={imgClassName}
+        onError={() => setHasError(true)}
+      />
+    </span>
+  );
+}

--- a/components/HeaderMenu.tsx
+++ b/components/HeaderMenu.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import AisaLogo from './AisaLogo';
+import styles from './header-menu.module.css';
+
+const NAV_ITEMS = [
+  { label: 'Somos Aisa', href: '#somos-aisa' },
+  { label: 'Divisiones', href: '#divisiones' },
+  { label: 'Proyectos', href: '#proyectos' },
+  { label: 'Actualidad', href: '#actualidad' },
+  { label: 'Sostenibilidad', href: '#sostenibilidad' }
+];
+
+export default function HeaderMenu() {
+  return (
+    <header className={styles.header}>
+      <div className={styles.inner}>
+        <Link href="/" className={styles.logoLink} aria-label="Ir al inicio">
+          <AisaLogo className={styles.logo} imgClassName={styles.logoImage} />
+        </Link>
+
+        <div className={styles.navWrapper}>
+          <nav className={styles.navPill} aria-label="Navegación principal">
+            <ul className={styles.navList}>
+              {NAV_ITEMS.map((item) => (
+                <li key={item.label}>
+                  <Link href={item.href} className={styles.navLink}>
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+
+        <div className={styles.actions}>
+          <span className={styles.language} aria-hidden="true">
+            ES / EN
+          </span>
+          <Link href="/contacto/" className={styles.contactLink}>
+            Contactar <span aria-hidden="true">↗</span>
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/header-menu.module.css
+++ b/components/header-menu.module.css
@@ -1,0 +1,189 @@
+.header {
+  position: fixed;
+  top: clamp(1rem, 4vw, 2.5rem);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  display: flex;
+  justify-content: center;
+  padding: 0 clamp(1rem, 5vw, 3rem);
+  pointer-events: none;
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(100%, 1100px);
+  min-height: 88px;
+  gap: clamp(1rem, 4vw, 2.25rem);
+  padding: clamp(0.5rem, 1vw + 0.5rem, 0.875rem) clamp(1.25rem, 4vw, 2.5rem);
+  background: rgba(11, 11, 11, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+}
+
+.logoLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  font-size: 1.125rem;
+  text-transform: uppercase;
+}
+
+.logoImage {
+  height: 32px;
+  width: auto;
+}
+
+.navWrapper {
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+}
+
+.navPill {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(2rem, 3vw + 1rem, 2.75rem);
+  padding: 0.6rem clamp(1.5rem, 3vw, 2.25rem);
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  backdrop-filter: blur(16px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 12px 35px rgba(0, 0, 0, 0.25);
+}
+
+.navList {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(2rem, 4vw, 2.5rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.navLink {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 0.25rem;
+  color: inherit;
+  text-decoration: none;
+  font-size: clamp(1rem, 0.95rem + 0.2vw, 1.125rem);
+  font-weight: 300;
+  letter-spacing: 0.01em;
+  transition: font-weight 0.2s ease, color 0.2s ease;
+}
+
+.navLink:hover,
+.navLink:focus-visible,
+.navLink[aria-current='page'] {
+  font-weight: 600;
+}
+
+.navLink:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.45);
+  outline-offset: 3px;
+  border-radius: 999px;
+}
+
+.actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  font-size: clamp(0.95rem, 0.9rem + 0.15vw, 1.0625rem);
+  letter-spacing: 0.01em;
+  font-weight: 300;
+}
+
+.language {
+  white-space: nowrap;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.contactLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.65rem 1.65rem;
+  background: linear-gradient(120deg, #ffffff, #d4d4d4);
+  color: #0b0b0b;
+  border-radius: 999px;
+  font-weight: 600;
+  min-height: 44px;
+  text-decoration: none;
+  letter-spacing: 0.01em;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.contactLink:hover,
+.contactLink:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.45);
+}
+
+.contactLink:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 3px;
+}
+
+@media (max-width: 768px) {
+  .header {
+    top: clamp(0.75rem, 3vw, 1.75rem);
+    padding: 0 1.25rem;
+  }
+
+  .inner {
+    width: 100%;
+    padding: 0.75rem clamp(1rem, 3vw, 1.75rem);
+  }
+
+  .navWrapper {
+    justify-content: flex-start;
+  }
+
+  .navPill {
+    width: 100%;
+    padding: 0.5rem 1.1rem;
+  }
+
+  .navList {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    gap: clamp(1.5rem, 6vw, 2.25rem);
+    width: 100%;
+    padding-bottom: 0.25rem;
+  }
+
+  .navList::-webkit-scrollbar {
+    display: none;
+  }
+
+  .navLink {
+    flex: 0 0 auto;
+    scroll-snap-align: center;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,7 +13,7 @@ html, body {
 }
 
 body {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: var(--font-poppins), system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: #000;
   color: #fff;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- Ajusta el layout global para cargar Poppins 300/600 mediante `next/font/google`, manteniendo el header flotante sin necesidad de adjuntar binarios en el repositorio.
- Elimina los archivos `.woff2` locales para evitar el error "Los archivos binarios no se admiten" al abrir la PR.

## Notas
- El resto del menú flotante permanece sin cambios y sigue respetando el hero existente.

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dac42ead90832d9857a7565986d995